### PR TITLE
Catch errors emitted by gulp-watch

### DIFF
--- a/generators/app/templates/gulp/server.js
+++ b/generators/app/templates/gulp/server.js
@@ -20,7 +20,7 @@ gulp.task('serve', ['clean', 'build', 'livereload'], function () {
     runSequence('build', function () {
       notifyLiveReload(e);
     });
-  });
+  }).on('error', conf.errorHandler('watch'));
   serve();
 });
 


### PR DESCRIPTION
My IDE (Webstorm) is generating and then immediately deleting these little temporary files during saves (file names like "`my-style.sass___jb_tmp___`"). This was causing a race condition with gulp-watch, which lead to frequent crashes (`ENOENT`). This patch will print out the errors instead.

Further improvement might be to just swallow the errors outright, but I wasn't comfortable going that far.
